### PR TITLE
feat: error handling global interceptor

### DIFF
--- a/bEnd/Kanban/routes.ts
+++ b/bEnd/Kanban/routes.ts
@@ -1,11 +1,11 @@
 import { Router } from "@oak/oak";
 
 import {
-    getUsers,
-    loginUser,
-    logoutUser,
-    refreshUser,
-    registerUser,
+	getUsers,
+	loginUser,
+	logoutUser,
+	refreshUser,
+	registerUser,
 } from "./controllers/userController.ts";
 import { validateUser } from "./validators/userValidator.ts";
 import { authHandler } from "./middleware/authHandler.ts";
@@ -15,7 +15,7 @@ const router = new Router();
 router.post("/signup", validateUser, registerUser);
 router.post("/signin", loginUser);
 router.post("/logout", logoutUser);
-router.post("/refresh", refreshUser);
+router.get("/refresh", refreshUser);
 router.get("/users", authHandler, getUsers);
 
 export default router;

--- a/fEnd/Kanban/.gitignore
+++ b/fEnd/Kanban/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/fEnd/Kanban/src/http/errors.ts
+++ b/fEnd/Kanban/src/http/errors.ts
@@ -1,0 +1,43 @@
+export class ApiError extends Error {
+	name: string;
+	status: number;
+
+	constructor(message: string, name: string, status: number) {
+		super(message);
+		this.name = name;
+		this.status = status;
+	}
+}
+
+export class UnauthorizedError extends ApiError {
+	constructor(message: string = "Access Unauthorized") {
+		super(message, "Unauthorized Error", 401);
+	}
+}
+
+export class BadRequestError extends ApiError {
+	errors: unknown[] | undefined;
+
+	constructor(message: string, errors: unknown[] | undefined) {
+		super(message, "Bad Request Error", 400);
+		this.errors = errors;
+	}
+}
+
+export class UnsuportedMediaTypeError extends ApiError {
+	constructor(message: string = "Expected JSON content type") {
+		super(message, "Unsuported Media Type Error", 415);
+	}
+}
+
+export class NetworkError extends ApiError {
+	constructor(message: string = "Unexpected Network Error") {
+		super(message, "Network Error", 0);
+	}
+}
+
+export class ServerError extends ApiError {
+	constructor(message: string, status: number) {
+		super(message, "Internal Server Error", status);
+	}
+}

--- a/fEnd/Kanban/src/interfaces/http-interfaces.ts
+++ b/fEnd/Kanban/src/interfaces/http-interfaces.ts
@@ -1,9 +1,18 @@
+import { AxiosRequestConfig } from "axios";
 import { User } from "./data-interfaces";
 
 export interface AuthResponse {
-	tokens: {
-		accessToken: string;
-		refreshToken: string;
-	};
 	user: User;
+	accessToken: string;
+}
+
+export interface ApiErrorResponse {
+	success: boolean;
+	name: string;
+	message: string;
+	errors?: unknown[];
+}
+
+export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+	retryCount?: number;
 }

--- a/fEnd/Kanban/src/pages/signin/types.ts
+++ b/fEnd/Kanban/src/pages/signin/types.ts
@@ -1,12 +1,11 @@
+import { ApiError } from "../../http/errors";
 import { User } from "../../interfaces/data-interfaces";
 
 export interface AuthStore {
 	user: User;
-	tokens: {
-		accessT: string;
-		refreshT: string;
-	};
+	accessToken: string;
 	isAuthenticated: boolean;
-	setToken: (accessT: string) => void;
+	error: ApiError | null;
 	signin: (email: string, password: string) => Promise<void>;
+	refreshAccessToken: () => Promise<void>;
 }

--- a/fEnd/Kanban/src/services/auth.service.ts
+++ b/fEnd/Kanban/src/services/auth.service.ts
@@ -1,10 +1,18 @@
 import { AxiosResponse } from "axios";
-import $api from "../http";
 import { AuthResponse } from "../interfaces/http-interfaces";
+import $defaultApi from "../http/index";
 
 export const signin = async (
 	email: string,
 	password: string
 ): Promise<AxiosResponse<AuthResponse>> => {
-	return $api.post<AuthResponse>("/signin", { email, password });
+	return await $defaultApi.post<AuthResponse>(
+		"/signin",
+		{ email, password },
+		{
+			headers: {
+				"Content-Type": "application/json; charser=utf-8",
+			},
+		}
+	);
 };

--- a/fEnd/Kanban/src/services/token.service.ts
+++ b/fEnd/Kanban/src/services/token.service.ts
@@ -1,3 +1,16 @@
+import { AxiosResponse } from "axios";
 import { useAuthStore } from "../pages/signin/store";
+import { AuthResponse } from "../interfaces/http-interfaces";
+import $api from "../http";
 
-export const getToken = () => useAuthStore.getState().tokens.accessT;
+export const getToken = () => useAuthStore.getState().accessToken;
+
+export const refreshAccessToken = async (): Promise<
+	AxiosResponse<AuthResponse>
+> => {
+	return await $api.get<AuthResponse>("/refresh", {
+		headers: {
+			"Content-Type": "application/json; charser=utf-8",
+		},
+	});
+};


### PR DESCRIPTION
Add custom error definitions.

Add response interceptor to the default axios instance that normalizes the errors and re-throws them to be handled in the store and subsequently in components.