### PR TITLE
feat: add a component that would persist the logged in user

### DIFF
--- a/bEnd/Kanban/controllers/userController.ts
+++ b/bEnd/Kanban/controllers/userController.ts
@@ -24,6 +24,7 @@ export async function registerUser(ctx: Context): Promise<void> {
 		httpOnly: true,
 		secure: false,
 		maxAge: 30 * 60 * 60 * 24,
+		sameSite: "none",
 	});
 	response.status = 201;
 	response.body = {

--- a/bEnd/Kanban/deno.json
+++ b/bEnd/Kanban/deno.json
@@ -13,6 +13,6 @@
 		"jwt": "https://deno.land/x/djwt@v3.0.2/mod.ts",
 		"sqlite": "https://deno.land/x/sqlite@v3.9.1/mod.ts",
 		"zod": "https://deno.land/x/zod@v3.23.8/mod.ts",
-		"x/cors": "https://deno.land/x/cors/mod.ts"
+		"x/cors": "https://deno.land/x/cors@v1.2.2/mod.ts"
 	}
 }

--- a/fEnd/Kanban/src/components/peristent-login/PeristentLogin.tsx
+++ b/fEnd/Kanban/src/components/peristent-login/PeristentLogin.tsx
@@ -1,0 +1,44 @@
+import { ReactNode, useEffect } from "react";
+import { useAuthStore } from "../../pages/signin/store";
+import { ApiError } from "../../http/errors";
+import ErrorNotification from "../error/ErrorNotification";
+import { toast } from "react-toastify";
+import { checkAuth } from "../../services/user.service";
+
+interface PersistentLoginProps {
+	children: ReactNode;
+}
+
+const PersistentLogin: React.FC<PersistentLoginProps> = ({ children }) => {
+	const refreshAccessToken = useAuthStore((state) => state.refreshAccessToken);
+	const loading = useAuthStore((state) => state.loading);
+	const error = useAuthStore((state) => state.error);
+	const setLoading = useAuthStore((state) => state.setLoading);
+
+	const showErrorNotification = (error: ApiError) => {
+		toast(<ErrorNotification error={error} />, {
+			className: "error-toast",
+			position: "top-center",
+			autoClose: 5000,
+			hideProgressBar: true,
+			closeOnClick: true,
+			pauseOnHover: true,
+			draggable: true,
+		});
+	};
+
+	useEffect(() => {
+		setLoading(true);
+		!checkAuth() ? refreshAccessToken() : setLoading(false);
+	}, []);
+
+	useEffect(() => {
+		if (error) {
+			showErrorNotification(error);
+		}
+	}, [error]);
+
+	return <>{loading ? <p>Loading Spinner ...</p> : children}</>;
+};
+
+export default PersistentLogin;

--- a/fEnd/Kanban/src/http/index.ts
+++ b/fEnd/Kanban/src/http/index.ts
@@ -18,9 +18,9 @@ const maxRetries: number = import.meta.env.VITE_MAX_RETRIES;
 const timeout: number = import.meta.env.VITE_TIMEOUT;
 
 const $defaultApi = axios.create({
-	withCredentials: true,
 	baseURL,
 	timeout,
+	withCredentials: true,
 });
 
 // Response interceptor to normalize the errors and
@@ -49,9 +49,9 @@ $defaultApi.interceptors.response.use(
 );
 
 export const $api = axios.create({
-	withCredentials: true,
 	baseURL,
 	timeout,
+	withCredentials: true,
 });
 
 $api.interceptors.request.use(

--- a/fEnd/Kanban/src/pages/signin/store.ts
+++ b/fEnd/Kanban/src/pages/signin/store.ts
@@ -15,6 +15,7 @@ const initialState = {
 	},
 	isAuthenticated: false,
 	error: null,
+	loading: false,
 	accessToken: "",
 };
 
@@ -22,20 +23,16 @@ export const useAuthStore = create<AuthStore>((set) => ({
 	...initialState,
 	signin: async (email, password) => {
 		try {
+			// set({ loading: true });
 			const response = await signin(email, password);
 			const { accessToken, user } = response.data;
 
 			set((state) => ({
 				...state,
-				user: {
-					id: user.id,
-					email: user.email,
-					firstName: user.firstName,
-					lastName: user.lastName,
-					role: user.role,
-				},
+				user,
 				isAuthenticated: true,
 				accessToken,
+				// loading: false,
 			}));
 		} catch (e) {
 			if (e instanceof ApiError) set({ error: e });
@@ -46,15 +43,40 @@ export const useAuthStore = create<AuthStore>((set) => ({
 						"Unknown Error",
 						0
 					),
+					// loading: false,
 				});
 		}
 	},
 	refreshAccessToken: async () => {
 		try {
+			// set({ loading: true });
 			const response = await refreshAccessToken();
-			console.log(JSON.stringify(response));
+			const { accessToken, user } = response.data;
+
+			set((state) => {
+				return {
+					...state,
+					user,
+					accessToken,
+					isAuthenticated: true,
+					error: null,
+					loading: false,
+				};
+			});
 		} catch (e) {
-			console.error(e);
+			if (e instanceof ApiError) set({ error: e });
+			else
+				set({
+					error: new ApiError(
+						"An unkown error has occured",
+						"Unknown Error",
+						0
+					),
+					// loading: false,
+				});
 		}
+	},
+	setLoading: (val) => {
+		set({ loading: val });
 	},
 }));

--- a/fEnd/Kanban/src/pages/signin/types.ts
+++ b/fEnd/Kanban/src/pages/signin/types.ts
@@ -6,6 +6,8 @@ export interface AuthStore {
 	accessToken: string;
 	isAuthenticated: boolean;
 	error: ApiError | null;
+	loading: boolean;
 	signin: (email: string, password: string) => Promise<void>;
 	refreshAccessToken: () => Promise<void>;
+	setLoading: (val: boolean) => void;
 }

--- a/fEnd/Kanban/src/router.tsx
+++ b/fEnd/Kanban/src/router.tsx
@@ -4,15 +4,18 @@ import Board from "./components/board/Board";
 import Signup from "./pages/signup/Signup";
 import Signin from "./pages/signin/Signin";
 import AuthProtectedRoute from "./utils/auth.guards";
+import PersistentLogin from "./components/peristent-login/PeristentLogin";
 
 const router = createBrowserRouter(
 	[
 		{
 			path: "/",
 			element: (
-				<AuthProtectedRoute>
-					<Home />
-				</AuthProtectedRoute>
+				<PersistentLogin>
+					<AuthProtectedRoute>
+						<Home />
+					</AuthProtectedRoute>
+				</PersistentLogin>
 			),
 			errorElement: <div>404 Not Found</div>, // This is to be implemented later.
 			children: [

--- a/fEnd/Kanban/src/services/token.service.ts
+++ b/fEnd/Kanban/src/services/token.service.ts
@@ -1,14 +1,14 @@
 import { AxiosResponse } from "axios";
 import { useAuthStore } from "../pages/signin/store";
 import { AuthResponse } from "../interfaces/http-interfaces";
-import $api from "../http";
+import $defaultApi from "../http";
 
 export const getToken = () => useAuthStore.getState().accessToken;
 
 export const refreshAccessToken = async (): Promise<
 	AxiosResponse<AuthResponse>
 > => {
-	return await $api.get<AuthResponse>("/refresh", {
+	return await $defaultApi.get<AuthResponse>("/refresh", {
 		headers: {
 			"Content-Type": "application/json; charser=utf-8",
 		},

--- a/fEnd/Kanban/src/utils/hooks.ts
+++ b/fEnd/Kanban/src/utils/hooks.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { refreshAccessToken } from "../services/token.service";
 
 type Procedure = (...args: any[]) => void;
 


### PR DESCRIPTION
Add a wrapper component that would issue a call to /refresh and renew the access token if a user refreshes the page or leaves for a different page.