### PR TITLE
feat: add trust this device functionality

### DIFF
--- a/fEnd/Kanban/src/components/peristent-login/PeristentLogin.tsx
+++ b/fEnd/Kanban/src/components/peristent-login/PeristentLogin.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { useAuthStore } from "../../pages/signin/store";
 // import { ApiError } from "../../http/errors";
 // import ErrorNotification from "../error/ErrorNotification";
@@ -10,9 +10,10 @@ interface PersistentLoginProps {
 }
 
 const PersistentLogin: React.FC<PersistentLoginProps> = ({ children }) => {
+	const [loading, setLoading] = useState(true);
+
 	const refreshAccessToken = useAuthStore((state) => state.refreshAccessToken);
-	const loading = useAuthStore((state) => state.loading);
-	const setLoading = useAuthStore((state) => state.setLoading);
+	const trustDevice = useAuthStore((state) => state.trustDevice);
 
 	// const showErrorNotification = (error: ApiError) => {
 	// 	toast(<ErrorNotification error={error} />, {
@@ -27,8 +28,16 @@ const PersistentLogin: React.FC<PersistentLoginProps> = ({ children }) => {
 	// };
 
 	useEffect(() => {
-		setLoading(true);
-		!checkAuth() ? refreshAccessToken() : setLoading(false);
+		const refresh = async () => {
+			try {
+				await refreshAccessToken();
+			} catch (error) {
+				console.log(error);
+			} finally {
+				setLoading(false);
+			}
+		};
+		!checkAuth() && trustDevice ? refresh() : setLoading(false);
 	}, []);
 
 	// useEffect(() => {
@@ -37,7 +46,17 @@ const PersistentLogin: React.FC<PersistentLoginProps> = ({ children }) => {
 	// 	}
 	// }, [error]);
 
-	return <>{loading ? <p>Loading Spinner ...</p> : children}</>;
+	return (
+		<>
+			{!trustDevice ? (
+				children
+			) : loading ? (
+				<p>Loading Spinner ...</p>
+			) : (
+				children
+			)}
+		</>
+	);
 };
 
 export default PersistentLogin;

--- a/fEnd/Kanban/src/index.css
+++ b/fEnd/Kanban/src/index.css
@@ -4,6 +4,7 @@
 	--color-font: #44476a;
 	--color-background: #e6e7ee;
 	--color-accent-blue: #2653ee;
+	--color-accent-grey-light: #dad7d7;
 }
 
 * {

--- a/fEnd/Kanban/src/pages/signin/Signin.module.css
+++ b/fEnd/Kanban/src/pages/signin/Signin.module.css
@@ -83,28 +83,12 @@
 	flex-direction: column;
 	width: 80%;
 }
-.label-email {
+.label-email,
+.label-password,
+.label-trust-device {
 	font-family: "QuicksandLight", sans-serif;
 }
-.email-input {
-	height: 2.5rem;
-	padding: 0.4rem 0.4rem;
-	border-radius: 0.5rem;
-	border: none;
-	appearance: none;
-	font-family: "QuicksandMedium", sans-serif;
-	background-color: #e6e7ee;
-	box-shadow: inset 2px 2px 5px #b8b9be, inset -3px -3px 7px #fff;
-}
-
-.password {
-	display: flex;
-	flex-direction: column;
-	width: 80%;
-}
-.label-password {
-	font-family: "QuicksandLight", sans-serif;
-}
+.email-input,
 .password-input {
 	height: 2.5rem;
 	padding: 0.4rem 0.4rem;
@@ -113,8 +97,72 @@
 	appearance: none;
 	font-family: "QuicksandMedium", sans-serif;
 	background-color: #e6e7ee;
+	border: 0.063rem var(--color-accent-grey-light) solid;
 	box-shadow: inset 2px 2px 5px #b8b9be, inset -3px -3px 7px #fff;
 }
+
+.password {
+	display: flex;
+	flex-direction: column;
+	width: 80%;
+}
+
+.trust-device {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 0.5rem;
+	width: 80%;
+}
+
+.trust-device-input {
+	height: 0;
+	width: 0;
+	visibility: hidden;
+}
+
+.label-trust-device {
+	cursor: pointer;
+	text-indent: -9999px;
+	width: 50px;
+	height: 27px;
+	/* background: grey; */
+	display: block;
+	border-radius: 100px;
+	position: relative;
+	border: 0.063rem var(--color-accent-grey-light) solid;
+	box-shadow: 5px 5px 10px #9f9f9f, -5px -5px 10px #ffffff;
+}
+
+.label-trust-device:after {
+	content: "";
+	position: absolute;
+	top: 2px;
+	left: 5px;
+	width: 22px;
+	height: 22px;
+	/* background: #fff; */
+	box-shadow: 5px 5px 10px #9f9f9f, -5px -5px 10px #ffffff;
+	border-radius: 90px;
+	transition: 0.3s;
+}
+
+.trust-device-input:checked + .label-trust-device {
+	border: 0.05rem solid #2653ee;
+}
+/* .label-trust-device:checked {
+	background: #2653ee;
+} */
+
+.trust-device-input:checked + .label-trust-device:after {
+	left: calc(100% - 5px);
+	transform: translateX(-100%);
+}
+
+.label-trust-device:active:after {
+	width: 30px;
+}
+
 .email-input:focus,
 .password-input:focus {
 	border: 0.05rem solid #2653ee;

--- a/fEnd/Kanban/src/pages/signin/Signin.tsx
+++ b/fEnd/Kanban/src/pages/signin/Signin.tsx
@@ -9,27 +9,15 @@ import { renderErrorToast } from "../../utils/toasts";
 const Signin = () => {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
+	const [loading, setLoading] = useState(false);
 
 	const signin = useAuthStore((state) => state.signin);
 	const error = useAuthStore((state) => state.error);
-	const loading = useAuthStore((state) => state.loading);
-	const setLoading = useAuthStore((state) => state.setLoading);
+	const trustDevice = useAuthStore((state) => state.trustDevice);
+	const setTrustDevice = useAuthStore((state) => state.setTrustDevice);
 
 	const navigate = useNavigate();
 	const location = useLocation();
-
-	const signinHandler = async (e: React.MouseEvent<HTMLButtonElement>) => {
-		setLoading(true);
-		//Validate the input or whatever
-		e.preventDefault();
-
-		await signin(email, password);
-
-		if (checkAuth()) {
-			const redirectTo = location.state?.from?.pathname || "/";
-			navigate(redirectTo, { replace: true });
-		}
-	};
 
 	useEffect(() => {
 		if (error) {
@@ -97,6 +85,22 @@ const Signin = () => {
 									}}
 								/>
 							</div>
+							<div className={styles["trust-device"]}>
+								<p>Trust this device</p>
+								<input
+									type="checkbox"
+									id="signin-trust-device"
+									className={styles["trust-device-input"]}
+									checked={trustDevice}
+									onChange={(e) => {
+										setTrustDevice(e.target.checked);
+									}}
+								/>
+								<label
+									htmlFor="signin-trust-device"
+									className={styles["label-trust-device"]}
+								></label>
+							</div>
 							<button
 								className={styles["signup-button"]}
 								onClick={signinHandler}
@@ -109,6 +113,20 @@ const Signin = () => {
 			)}
 		</>
 	);
+
+	async function signinHandler(e: React.MouseEvent<HTMLButtonElement>) {
+		setLoading(true);
+		//Validate the input or whatever
+		e.preventDefault();
+
+		await signin(email, password);
+		setLoading(false);
+
+		if (checkAuth()) {
+			const redirectTo = location.state?.from?.pathname || "/";
+			navigate(redirectTo, { replace: true });
+		}
+	}
 };
 
 export default Signin;

--- a/fEnd/Kanban/src/pages/signin/store.ts
+++ b/fEnd/Kanban/src/pages/signin/store.ts
@@ -15,7 +15,7 @@ const initialState = {
 	},
 	isAuthenticated: false,
 	error: null,
-	loading: false,
+	trustDevice: JSON.parse(localStorage.getItem("trustDevice") || "false"),
 	accessToken: "",
 };
 
@@ -32,7 +32,6 @@ export const useAuthStore = create<AuthStore>((set) => ({
 				isAuthenticated: true,
 				error: null,
 				accessToken,
-				loading: false,
 			}));
 		} catch (e) {
 			if (e instanceof ApiError) set({ error: e });
@@ -59,7 +58,6 @@ export const useAuthStore = create<AuthStore>((set) => ({
 					accessToken,
 					isAuthenticated: true,
 					error: null,
-					loading: false,
 				};
 			});
 		} catch (e) {
@@ -71,7 +69,6 @@ export const useAuthStore = create<AuthStore>((set) => ({
 						"Unknown Error",
 						0
 					),
-					loading: false,
 				});
 		}
 	},
@@ -86,7 +83,6 @@ export const useAuthStore = create<AuthStore>((set) => ({
 				isAuthenticated: true,
 				accessToken,
 				error: null,
-				loading: false,
 			}));
 		} catch (e) {
 			if (e instanceof ApiError) set({ error: e });
@@ -97,11 +93,11 @@ export const useAuthStore = create<AuthStore>((set) => ({
 						"Unknown Error",
 						0
 					),
-					loading: false,
 				});
 		}
 	},
-	setLoading: (val) => {
-		set({ loading: val });
+	setTrustDevice: (val) => {
+		localStorage.setItem("trustDevice", JSON.stringify(val));
+		set({ trustDevice: val });
 	},
 }));

--- a/fEnd/Kanban/src/pages/signin/types.ts
+++ b/fEnd/Kanban/src/pages/signin/types.ts
@@ -7,9 +7,9 @@ export interface AuthStore {
 	accessToken: string;
 	isAuthenticated: boolean;
 	error: ApiError | null;
-	loading: boolean;
+	trustDevice: boolean;
 	signin: (email: string, password: string) => Promise<void>;
 	signup: (credentials: Credentials) => Promise<void>;
+	setTrustDevice: (val: boolean) => void;
 	refreshAccessToken: () => Promise<void>;
-	setLoading: (val: boolean) => void;
 }

--- a/fEnd/Kanban/src/pages/signup/Signup.tsx
+++ b/fEnd/Kanban/src/pages/signup/Signup.tsx
@@ -8,18 +8,18 @@ import { useAuthStore } from "../signin/store";
 import { renderErrorToast, renderInfoToast } from "../../utils/toasts";
 import { UserRole } from "../../interfaces/data-interfaces";
 import { checkAuth } from "../../services/user.service";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import ErrorNotification from "../../components/error/ErrorNotification";
 
 const Signup = () => {
+	const [loading, setLoading] = useState(false);
+
 	const columns = useSignupStore((state) => state.columns);
 	const moveTask = useSignupStore((state) => state.moveTask);
 	const tasks = useSignupStore((state) => state.tasks);
 
 	const signup = useAuthStore((state) => state.signup);
 	const error = useAuthStore((state) => state.error);
-	const loading = useAuthStore((state) => state.loading);
-	const setLoading = useAuthStore((state) => state.setLoading);
 
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -80,12 +80,11 @@ const Signup = () => {
 	);
 
 	async function signupHandler() {
-		// setLoading(true);
+		setLoading(true);
 		// This value is hardcoded so, we can guarantee that this can't be undefined
 		const done = columns.find((column) => column.id === "done")!;
 		if (done.taskIds.length < 4) {
 			renderInfoToast('Please drag all tasks to the "Done" column');
-			renderErrorToast("Some Error Message");
 			return;
 		}
 
@@ -119,6 +118,7 @@ const Signup = () => {
 		);
 
 		await signup(credentials);
+		setLoading(false);
 		if (checkAuth()) {
 			const redirectTo = location.state?.from?.pathname || "/";
 			navigate(redirectTo, { replace: true });

--- a/fEnd/Kanban/src/utils/auth.guards.tsx
+++ b/fEnd/Kanban/src/utils/auth.guards.tsx
@@ -1,24 +1,5 @@
-// import { Navigate } from "react-router-dom";
-// import { checkAuth } from "../services/user.service";
-// import { ReactNode } from "react";
-
-// interface ProtectedRoutesProps {
-// 	children: ReactNode;
-// }
-
-// const AuthProtectedRoute: React.FC<ProtectedRoutesProps> = ({ children }) => {
-// 	const isAuthenticated = checkAuth();
-
-// 	if (!isAuthenticated) {
-// 		return <Navigate to={"/signin"} replace />;
-// 	}
-
-// 	return <>{children}</>;
-// };
-
-// export default AuthProtectedRoute;
 import { Navigate } from "react-router-dom";
-import { useAuthStore } from "../pages/signin/store"; // Assuming the store is located here
+import { useAuthStore } from "../pages/signin/store";
 import { useState, useEffect } from "react";
 
 interface ProtectedRoutesProps {
@@ -29,19 +10,16 @@ const AuthProtectedRoute: React.FC<ProtectedRoutesProps> = ({ children }) => {
 	const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 	const [loading, setLoading] = useState(true);
 
-	// Wait until authentication state is resolved or loading is complete
 	useEffect(() => {
 		if (isAuthenticated !== undefined) {
-			setLoading(false); // Once the authentication status is determined, stop loading
+			setLoading(false);
 		}
 	}, [isAuthenticated]);
 
-	// While loading, don't render anything
 	if (loading) {
-		return <div>Loading...</div>; // Or your loading spinner
+		return <div>Loading...</div>;
 	}
 
-	// Redirect to sign-in page if not authenticated
 	if (!isAuthenticated) {
 		return <Navigate to="/signin" replace />;
 	}


### PR DESCRIPTION
Implement a toggle on the signin page that allows the user to mark a specific device as trusted. If trusted, the persisten login functionality will work, otherwise, the user will be logged out on refresh or when the access token expires.