### PR TITLE
feat: Declare types and interfaces.Set up DB

### DIFF
--- a/bEnd/Kanban/database/clearDB.ts
+++ b/bEnd/Kanban/database/clearDB.ts
@@ -1,16 +1,21 @@
 import { DB } from "sqlite";
 
 export function clearDB(): void {
-    const _db = new DB("kanban.db");
+	const _db = new DB("kanban.db");
 
-    // Create the users table
-    _db.query(`DROP TABLE users`);
-
-    // Create the tokens table
-
-    _db.query(`DROP TABLE tokens`);
-
-    _db.close();
+	try {
+		_db.query(`DROP TABLE IF EXISTS comments`);
+		_db.query(`DROP TABLE IF EXISTS tasktodos`);
+		_db.query(`DROP TABLE IF EXISTS tasks`);
+		_db.query(`DROP TABLE IF EXISTS tokens`);
+		_db.query(`DROP TABLE IF EXISTS users`);
+		_db.query(`DROP TABLE IF EXISTS boards`);
+		_db.query(`DROP TABLE IF EXISTS columns`);
+	} catch (e) {
+		console.log(`[ERROR]: clearDB ==> ${e}`);
+	} finally {
+		_db.close();
+	}
 }
 
 clearDB();

--- a/bEnd/Kanban/database/dbSetup.ts
+++ b/bEnd/Kanban/database/dbSetup.ts
@@ -9,10 +9,10 @@
 import { DB } from "sqlite";
 
 export function initializeDatabase(): void {
-    const _db = new DB("kanban.db");
+	const _db = new DB("kanban.db");
 
-    // Create the users table
-    _db.query(`
+	// Create the users table
+	_db.query(`
             CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
                 firstName TEXT NOT NULL,
@@ -23,16 +23,70 @@ export function initializeDatabase(): void {
             ) 
         `);
 
-    // Create the tokens table
-
-    _db.query(`
+	// Create the tokens table
+	_db.query(`
             CREATE TABLE IF NOT EXISTS tokens (
                 id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
                 userId INTEGER NOT NULL,
                 refreshToken TEXT NOT NULL UNIQUE,
-                FOREIGN KEY(userId) REFERENCES users(id)
+                FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
         ) 
     `);
 
-    _db.close();
+	// Create the boards table
+	_db.query(`
+            CREATE TABLE IF NOT EXISTS boards (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+                title TEXT NOT NULL
+            )
+        `);
+
+	// Create the columns table
+	_db.query(`
+            CREATE TABLE IF NOT EXISTS columns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+                title TEXT NOT NULL
+            ) 
+        `);
+
+	// Create the tasks table
+	_db.query(`
+            CREATE TABLE IF NOT EXISTS tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+                userId INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                description TEXT,
+                status TEXT NOT NULL CHECK (status IN ('new', 'in_progress', 'testing', 'done')),
+                tag TEXT,
+                createdOn TEXT NOT NULL,
+                completedOn TEXT,
+                FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
+            ) 
+        `);
+
+	// Create the tasktodos table
+	_db.query(`
+            CREATE TABLE IF NOT EXISTS tasktodos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+                taskId INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                completed INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY(taskId) REFERENCES tasks(id) ON DELETE CASCADE
+            ) 
+        `);
+
+	// Create the comments table
+	_db.query(`
+            CREATE TABLE IF NOT EXISTS comments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+                taskId INTEGER NOT NULL,
+                userId INTEGER NOT NULL,
+                content TEXT NOT NULL,
+                createdOn TEXT NOT NULL,
+                FOREIGN KEY(taskId) REFERENCES tasks(id) ON DELETE CASCADE,
+                FOREIGN KEY(userId) REFERENCES users(id) ON DELETE CASCADE
+            ) 
+        `);
+
+	_db.close();
 }

--- a/bEnd/Kanban/deno.json
+++ b/bEnd/Kanban/deno.json
@@ -1,6 +1,7 @@
 {
 	"tasks": {
-		"dev": "deno run --watch --allow-net --allow-read --allow-write --allow-env main.ts"
+		"dev": "deno run --watch --allow-net --allow-read --allow-write --allow-env main.ts",
+		"clear": "deno run --allow-read --allow-write ./database/clearDB.ts"
 	},
 	"imports": {
 		"@oak/oak": "jsr:@oak/oak@^17.1.2",
@@ -13,6 +14,7 @@
 		"jwt": "https://deno.land/x/djwt@v3.0.2/mod.ts",
 		"sqlite": "https://deno.land/x/sqlite@v3.9.1/mod.ts",
 		"zod": "https://deno.land/x/zod@v3.23.8/mod.ts",
-		"x/cors": "https://deno.land/x/cors@v1.2.2/mod.ts"
+		"x/cors": "https://deno.land/x/cors@v1.2.2/mod.ts",
+		"crypto": "node:crypto"
 	}
 }

--- a/bEnd/Kanban/services/boardService.ts
+++ b/bEnd/Kanban/services/boardService.ts
@@ -1,0 +1,1 @@
+export function saveBoard() {}

--- a/bEnd/Kanban/types/entityTypes.ts
+++ b/bEnd/Kanban/types/entityTypes.ts
@@ -1,0 +1,45 @@
+export enum TaskStatus {
+	New,
+	InProgress,
+	Testing,
+	Done,
+}
+
+export interface Board {
+	[key: string]: unknown;
+	id: number;
+	title: string;
+}
+
+export interface Column {
+	[key: string]: unknown;
+	id: number;
+	title: string;
+}
+
+export interface Task {
+	[key: string]: unknown;
+	id: number;
+	userId: number;
+	title: string;
+	description: string;
+	status: TaskStatus;
+	tag: string;
+	createdOn: Date;
+	completedOn: Date;
+}
+
+export interface TaskTodos {
+	id: number;
+	taskId: number;
+	title: string;
+	completed: boolean;
+}
+
+export interface Comments {
+	id: number;
+	taskId: number;
+	userId: number;
+	content: string;
+	createdOn: Date;
+}

--- a/bEnd/Kanban/types/messageTypes.ts
+++ b/bEnd/Kanban/types/messageTypes.ts
@@ -1,0 +1,111 @@
+import { TaskStatus } from "./entityTypes.ts";
+
+export enum MessageType {
+	CreateBoard,
+	DeleteBoard,
+	UpdateBoard,
+
+	CreateColumn,
+	DeleteColumn,
+	UpdateColumn,
+
+	CreateTask,
+	DeleteTask,
+	UpdateTask,
+
+	CreateComment,
+	DeleteComment,
+
+	CreateTaskToDo,
+	DeleteTaskToDo,
+	UpdateTaskToDo,
+}
+
+export interface CreateBoardPayload {
+	title: string;
+}
+
+export interface UpdateBoardPayload {
+	title: string;
+}
+
+export interface DeleteBoardPaylod {
+	id: number;
+}
+
+export interface CreateColumnPayload {
+	title: string;
+}
+
+export interface UpdateColumnPayload {
+	title: string;
+}
+
+export interface DeleteColumnPaylod {
+	id: number;
+}
+
+export interface CreateTaskPayload {
+	userId: number;
+	title: string;
+	description?: string;
+	status: TaskStatus;
+	tag?: string;
+	createdOn: Date;
+}
+
+export interface UpdateTaskPayload {
+	userId?: number;
+	title?: string;
+	description?: string;
+	status?: TaskStatus;
+	tag?: string;
+	completedOn?: Date;
+}
+
+export interface DeleteTaskPayload {
+	id: number;
+}
+
+export interface CreateCommentPayload {
+	taskId: number;
+	userId: number;
+	content: string;
+	createdOn: Date;
+}
+
+export interface DeleteCommentPayload {
+	id: number;
+}
+
+export interface CreateTaskToDoPayload {
+	taskId: number;
+	title: string;
+	completed: boolean;
+}
+
+export interface UpdateTaskToDoPayload {
+	taskId: number;
+	title?: string;
+	completed?: boolean;
+}
+
+export interface DeleteTaskToDoPayload {
+	id: number;
+}
+
+export type Message =
+	| { type: MessageType.CreateBoard; payload: CreateBoardPayload }
+	| { type: MessageType.DeleteBoard; payload: DeleteBoardPaylod }
+	| { type: MessageType.UpdateBoard; payload: UpdateBoardPayload }
+	| { type: MessageType.CreateColumn; payload: CreateColumnPayload }
+	| { type: MessageType.UpdateColumn; payload: UpdateColumnPayload }
+	| { type: MessageType.DeleteColumn; payload: DeleteColumnPaylod }
+	| { type: MessageType.CreateTask; payload: CreateTaskPayload }
+	| { type: MessageType.UpdateTask; payload: UpdateTaskPayload }
+	| { type: MessageType.DeleteTask; payload: DeleteTaskPayload }
+	| { type: MessageType.CreateTaskToDo; payload: CreateTaskToDoPayload }
+	| { type: MessageType.UpdateTaskToDo; payload: UpdateTaskToDoPayload }
+	| { type: MessageType.DeleteTaskToDo; payload: DeleteTaskToDoPayload }
+	| { type: MessageType.CreateComment; payload: CreateCommentPayload }
+	| { type: MessageType.DeleteComment; payload: DeleteCommentPayload };


### PR DESCRIPTION
Declared the interfaces and enums for each entity as well as a unified message interface for different actions issued by the client. Created additional startup querries for the new database tables. Updated the clearDB.ts script and extracted the action into a deno task.