### PR TITLE
fix: Remove the connection pool

### DIFF
--- a/bEnd/Kanban/https/controllers/data.controller.ts
+++ b/bEnd/Kanban/https/controllers/data.controller.ts
@@ -1,42 +1,42 @@
 import { Context } from "@oak/oak/context";
 import {
-    boardColumns,
-    Column,
-    columnColumns,
-    Section,
-    sectionColumns,
-    taskColumns,
+  boardColumns,
+  Column,
+  columnColumns,
+  Section,
+  sectionColumns,
+  taskColumns,
 } from "../../websockets/types/entities.ts";
 import { createModel } from "../../storage/orm/orm.ts";
 import { RouterContext } from "@oak/oak/router";
 
-export async function getSections(ctx: Context): Promise<void> {
-    const { response } = ctx;
+export function getSections(ctx: Context): void {
+  const { response } = ctx;
 
-    const SectionModel = createModel<Section>("sections", sectionColumns);
-    const result = await SectionModel.findWithJoin("boards", "id", "section", {
-        primary: sectionColumns,
-        joined: boardColumns,
-    });
-    response.body = result;
+  const SectionModel = createModel<Section>("sections", sectionColumns);
+  const result = SectionModel.findWithJoin("boards", "id", "section", {
+    primary: sectionColumns,
+    joined: boardColumns,
+  });
+  response.body = result;
 }
 
-export async function getColumns(
-    ctx: RouterContext<"/columns/:boardId">,
-): Promise<void> {
-    const { response } = ctx;
-    const boardId = parseInt(ctx.params.boardId);
-    const ColumnModel = createModel<Column>("columns", columnColumns);
-    const columns = await ColumnModel.findWithJoin(
-        "tasks",
-        "id",
-        "columnId",
-        {
-            primary: columnColumns,
-            joined: taskColumns,
-        },
-        { boardId: boardId },
-    );
+export function getColumns(
+  ctx: RouterContext<"/columns/:boardId">,
+): void {
+  const { response } = ctx;
+  const boardId = parseInt(ctx.params.boardId);
+  const ColumnModel = createModel<Column>("columns", columnColumns);
+  const columns = ColumnModel.findWithJoin(
+    "tasks",
+    "id",
+    "columnId",
+    {
+      primary: columnColumns,
+      joined: taskColumns,
+    },
+    { boardId: boardId },
+  );
 
-    response.body = columns;
+  response.body = columns;
 }

--- a/bEnd/Kanban/https/services/user.service.ts
+++ b/bEnd/Kanban/https/services/user.service.ts
@@ -20,28 +20,22 @@ export async function register(user: User): Promise<{
   user: Omit<User, "password">;
 }> {
   const UserModel = createModel<User>("users", userColumns);
-
-  const candidate = await UserModel.findOne({ email: user.email });
+  const candidate = UserModel.findOne({ email: user.email });
   if (candidate) {
     throw ApiError.BadRequestError(
       `The user with the email: ${user.email} already exists`,
     );
   }
-
   const hashedPassword = await hash(user.password);
   user.password = hashedPassword;
-
-  const lastInsertedRowId = await UserModel.insert(user);
+  const lastInsertedRowId = UserModel.insert(user);
   if (!lastInsertedRowId) throw DatabaseError.ConflictError();
-
   /** If we reach this, the previous insert has succeded. We can guarantee lastInsertedRowId exists */
-  const insertedUser = await UserModel.findOne({ id: lastInsertedRowId });
+  const insertedUser = UserModel.findOne({ id: lastInsertedRowId });
   if (!insertedUser) throw DatabaseError.ConflictError();
-
   const tokens = await generateTokens(insertedUser);
   const { refreshToken } = tokens;
-  await saveToken({ userId: insertedUser.id!, refreshToken });
-
+  saveToken({ userId: insertedUser.id!, refreshToken });
   return {
     tokens,
     user: userDto(insertedUser),
@@ -50,55 +44,48 @@ export async function register(user: User): Promise<{
 
 export async function login(email: string, password: string) {
   const UserModel = createModel<User>("users", userColumns);
-
-  const candidate = await UserModel.findOne({ email: email });
+  const candidate = UserModel.findOne({ email: email });
   if (!candidate) {
     throw ApiError.BadRequestError(
       "The password or the email is incorrect",
     );
   }
-
   const arePassEqual = await compare(password, candidate.password);
   if (!arePassEqual) {
     throw ApiError.BadRequestError(
       "The password or the email is incorrect",
     );
   }
-
   const tokens = await generateTokens(candidate);
   const { refreshToken } = tokens;
-  await saveToken({ userId: candidate.id!, refreshToken });
-
+  saveToken({ userId: candidate.id!, refreshToken });
   return {
     tokens,
     user: userDto(candidate),
   };
 }
 
-export async function logout(token: string): Promise<string> {
-  return await removeToken(token);
+export function logout(token: string): string {
+  return removeToken(token);
 }
 
 export async function refresh(token: string) {
   const userData = await validateToken(token, "refresh");
-
   const UserModel = createModel<User>("users", userColumns);
-  const user = await UserModel.findOne({ id: userData.id });
+  const user = UserModel.findOne({ id: userData.id });
   if (!user) throw DatabaseError.ConflictError();
-
   const tokens = await generateTokens(user!);
   const { refreshToken } = tokens;
-  await saveToken({ userId: user!.id!, refreshToken });
-
+  saveToken({ userId: user!.id!, refreshToken });
   return {
     tokens,
     user: userDto(user),
   };
 }
 
-export async function getAllUsers(): Promise<Partial<User>[]> {
+export function getAllUsers(): Partial<User>[] {
   const UserModel = createModel<User>("users", userColumns);
-  const users = await UserModel.findAll();
+  const users = UserModel.findAll();
   if (!users) throw DatabaseError.ConflictError();
   const usersDto = users.map((user) => userDto(user));
   return usersDto;

--- a/bEnd/Kanban/https/utils/config.ts
+++ b/bEnd/Kanban/https/utils/config.ts
@@ -9,7 +9,7 @@ await load({
 export const config = {
   path: resolve(Deno.cwd(), "storage", "database", "kanban.db"),
   hostname: Deno.env.get("H") ?? "localhost",
-  port: Deno.env.get("P") ?? 5000,
+  port: Deno.env.get("P") ?? "5000",
   accessTokenKey: await crypto.subtle.generateKey(
     { name: "HMAC", hash: "SHA-512" },
     true,

--- a/bEnd/Kanban/main.ts
+++ b/bEnd/Kanban/main.ts
@@ -28,11 +28,7 @@ app.addEventListener("close", () => {
 const port = parseInt(config.port!);
 const hostname = config.hostname;
 
-//const hostname = "127.0.0.1";
-//const port = 5000;
-
 console.log(`Listening to ${config.hostname} on port: ${config.port}`);
-//console.log(`Listening to ${hostname} on port: ${port}`);
 try {
   await app.listen({
     port,

--- a/bEnd/Kanban/storage/database/connectionPool.ts
+++ b/bEnd/Kanban/storage/database/connectionPool.ts
@@ -26,37 +26,22 @@ export function aquireConnection(): Promise<DB> {
     const attemptAquire = () => {
       const now = Date.now();
 
-      console.log("Attempting to acquire a connection...");
-      console.log(`Connections available: ${connections.length}`);
-      console.log(`Queue size: ${queue.length}`);
       if (connections.length > 0) {
         resolve(connections.pop()!);
       } else if (now - startTime >= timeout) {
         reject(
-          new Error(
-            "Connection timeout: No available database connections",
-          ),
+          new Error("Connection timeout: No available database connections"),
         );
       } else {
         queue.push(attemptAquire);
       }
     };
+
     attemptAquire();
   });
 }
 
-//export function releaseConnection(connection: DB): void {
-//  connections.push(connection);
-//  if (queue.length > 0) {
-//    const nextRequest = queue.shift();
-//    if (nextRequest) nextRequest();
-//    console.log("connection released");
-//  }
-//  console.log("connection released");
-//}
-
 export function releaseConnection(connection: DB): void {
-  console.log("Releasing a connection...");
   connections.push(connection);
 
   // Process the next queued request, if any
@@ -67,7 +52,6 @@ export function releaseConnection(connection: DB): void {
       break; // Only process one task per release
     }
   }
-  console.log(`Connections available after release: ${connections.length}`);
 }
 
 export function closePool(): void {

--- a/fEnd/Kanban/package-lock.json
+++ b/fEnd/Kanban/package-lock.json
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/fEnd/Kanban/src/http/index.ts
+++ b/fEnd/Kanban/src/http/index.ts
@@ -17,8 +17,6 @@ const baseURL: string = import.meta.env.VITE_BASE_URL;
 const maxRetries: number = import.meta.env.VITE_MAX_RETRIES;
 const timeout: number = import.meta.env.VITE_TIMEOUT;
 
-console.log(baseURL);
-
 const $defaultApi = axios.create({
   baseURL,
   timeout,
@@ -30,6 +28,7 @@ const $defaultApi = axios.create({
 $defaultApi.interceptors.response.use(
   (response) => response,
   async (error: AxiosError<ApiErrorResponse>) => {
+    console.log(error);
     const config = error.config as CustomAxiosRequestConfig;
     if (!config || config.retryCount === undefined) {
       config.retryCount = 0;

--- a/fEnd/Kanban/src/services/auth.service.ts
+++ b/fEnd/Kanban/src/services/auth.service.ts
@@ -4,26 +4,26 @@ import $defaultApi from "../http/index";
 import { Credentials } from "../pages/signup/types";
 
 export const signin = async (
-	email: string,
-	password: string
+  email: string,
+  password: string,
 ): Promise<AxiosResponse<AuthResponse>> => {
-	return await $defaultApi.post<AuthResponse>(
-		"/signin",
-		{ email, password },
-		{
-			headers: {
-				"Content-Type": "application/json; charser=utf-8",
-			},
-		}
-	);
+  return await $defaultApi.post<AuthResponse>(
+    "/signin",
+    { email, password },
+    {
+      headers: {
+        "Content-Type": "application/json; charser=utf-8",
+      },
+    },
+  );
 };
 
 export const signup = async (
-	credentials: Credentials
+  credentials: Credentials,
 ): Promise<AxiosResponse<AuthResponse>> => {
-	return await $defaultApi.post<AuthResponse>("/signup", credentials, {
-		headers: {
-			"Content-Type": "application/json; charser=utf-8",
-		},
-	});
+  return await $defaultApi.post<AuthResponse>("/signup", credentials, {
+    headers: {
+      "Content-Type": "application/json; charser=utf-8",
+    },
+  });
 };

--- a/fEnd/Kanban/vite.config.ts
+++ b/fEnd/Kanban/vite.config.ts
@@ -12,5 +12,13 @@ export default defineConfig({
     },
     port: 5173,
     host: "127.0.0.1",
+    //proxy: {
+    //  "/api": {
+    //    target: "https://127.0.0.1:5000",
+    //    changeOrigin: true,
+    //    secure: false, // Allow self-signed certs
+    //    rewrite: (path) => path.replace(/^\/api/, ""),
+    //  },
+    //},
   },
 });


### PR DESCRIPTION
Since SQLITE works on a single file, concurrent access caused deadlocks. Removed the connection pool, which wasn't providing any noticeable performance boost. Went back to serialized DB access.